### PR TITLE
refactor: specify version of LibreOffice to be used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,34 @@
-FROM amazoncorretto:17-alpine
+FROM ubuntu:22.04
+LABEL authors="Anton Georgiev"
 
-RUN apk --no-cache add fontconfig libreoffice && \
-    rm -rf /tmp/* /var/tmp/* /var/cache/apk/*
+ENV LIBREOFFICE_VERSION=7.5.7
+
+RUN apt-get update && apt-get install -y \  
+  libcairo2 \ 
+  libxinerama1 \ 
+  libxt6 \
+  wget \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://download.documentfoundation.org/libreoffice/stable/${LIBREOFFICE_VERSION}/deb/x86_64/LibreOffice_${LIBREOFFICE_VERSION}_Linux_x86-64_deb.tar.gz
+
+ADD install-libreoffice.sh /
+RUN chmod +x /install-libreoffice.sh
+RUN /install-libreoffice.sh LibreOffice_${LIBREOFFICE_VERSION}_Linux_x86-64_deb.tar.gz
+RUN rm LibreOffice_${LIBREOFFICE_VERSION}_Linux_x86-64_deb.tar.gz
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get -y install default-jre-headless && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN ["/bin/bash", "-c", "mv LibreOffice_* unarchivedLO"] # sometimes the unarchived directory contains additional characters
+WORKDIR unarchivedLO/DEBS/
+
+RUN dpkg -i *.deb
+RUN rm -rf *.deb
+
+RUN ln -s /usr/local/bin/libreoffice7.5 /usr/bin/soffice
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ LABEL authors="Anton Georgiev"
 ENV LIBREOFFICE_VERSION=7.5.7
 
 RUN apt-get update && apt-get install -y \  
+  default-jre-headless \
   libcairo2 \ 
   libxinerama1 \ 
   libxt6 \
@@ -18,17 +19,11 @@ RUN chmod +x /install-libreoffice.sh
 RUN /install-libreoffice.sh LibreOffice_${LIBREOFFICE_VERSION}_Linux_x86-64_deb.tar.gz
 RUN rm LibreOffice_${LIBREOFFICE_VERSION}_Linux_x86-64_deb.tar.gz
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive \
-    apt-get -y install default-jre-headless && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN ["/bin/bash", "-c", "mv LibreOffice_* unarchivedLO"] # sometimes the unarchived directory contains additional characters
+RUN ["/bin/sh", "-c", "mv LibreOffice_* unarchivedLO"] # sometimes the unarchived directory contains additional characters
 WORKDIR unarchivedLO/DEBS/
 
 RUN dpkg -i *.deb
 RUN rm -rf *.deb
 
-RUN ln -s /usr/local/bin/libreoffice7.5 /usr/bin/soffice
+RUN ["/bin/sh", "-c", "ln -s /usr/local/bin/libreoffice* /usr/bin/soffice"]
 

--- a/install-libreoffice.sh
+++ b/install-libreoffice.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+    
+# A script to install or update libreoffice releases properly
+# Originally from https://wiki.documentfoundation.org/Documentation/Install/Linux#Script_For_Installing
+# Changes:
+# AG: switched from bash to sh
+
+if [[ "$1" == "-x" ]]; then
+    shift
+    set -x
+fi
+    
+me=`basename $0`
+Usage() {
+    echo "Usage: $me [-x][-h|--help] <gzipped-tarball> [<gzipped-tarball>...]"
+    exit 0
+}
+    
+if [[ -z "$1" || "$1" == "-h" || "$1" == "--help" ]]; then Usage; fi
+    
+# Change these to install on rpm base systems
+tgt=DEBS
+cmd="dpkg -i"
+sfx=deb
+    
+for tb in $*; do
+    if [[ ! -f $tb ]]; then
+        if [[ -f "$tb.tgz" ]]; then
+            tb="$tb.tgz"
+        elif [[ -f "$tb.tar.gz" ]]; then
+            tb="$tb.tar.gz"
+        else
+            echo "Can't find $tb or $tb.tgz or $tb.tar.gz - skipping..."
+            read ln
+            continue
+        fi
+    fi
+    
+    # find out what the name of the uncompressed subdirectory will be
+    dst=`tar tzf $tb 2> /dev/null | head -1 | awk -F/ '{print $1}'`
+    tar xzf $tb
+    if [[ ! -d $dst/$tgt ]]; then
+        echo "Can't find $me directory $dst/$tgt - skipping..."
+        read ln
+        continue
+    fi
+    
+    # install or update, depending on how I was called
+    cd $dst/$tgt
+    case $me in
+        loinst)
+            sudo $cmd *.$sfx
+            if [[ -d desktop-integration ]]; then
+                cd desktop-integration
+                sudo $cmd *.$sfx
+                cd ..
+            fi
+            cd ../..
+        ;;
+        loupdate)
+            cd ..
+            sudo ./update
+            cd ..
+        ;;
+    esac
+    
+    # delete the installation directory
+    /bin/rm -rf $dst
+done
+    
+echo ""
+


### PR DESCRIPTION
* with alpine I did not find a way to reliably use the .deb packages downloadable from LibreOffice's official website, so I switched to Ubuntu
* Had to add a couple of libraries to handle errors
  * `libxt6` added to handle `no suitable windowing system found, exiting.`
  * `libcairo2`, `libxinerama1` to handle ` error while loading shared libraries: libXinerama.so.1: cannot open shared object file: No such file or directory`
* Had to do some directory renaming `RUN ["/bin/sh", "-c", "mv LibreOffice_* unarchivedLO"]` because the expanded archive contained an unexpected minor version in the filename
* The new image is significantly larger even after wiping out the workspace

```
REPOSITORY        TAG       IMAGE ID       CREATED          SIZE
bbb-soffice       latest    7f951ecb7903   16 seconds ago   1.63GB      <----after
---
bbb-soffice       latest    554f462e7286   5 hours ago      919MB       <----before

```