### PR TITLE
Drop the timestamp from the docker tag, we'll do it on git tag only

### DIFF
--- a/.github/workflows/ci.build.push.yml
+++ b/.github/workflows/ci.build.push.yml
@@ -32,18 +32,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Get current date
-        id: date
-        if: contains(env.DOCKER_BUILD_ENABLED, 'true')
-        shell: bash
-        run: echo "time=$(date +'%Y-%m-%d-%H%M%S')" >> $GITHUB_OUTPUT
-
       - name: Build and Push branch
         if: contains(env.DOCKER_BUILD_ENABLED, 'true')
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: "bigbluebutton/bbb-libreoffice:${{ github.ref_name }}--${{ steps.date.outputs.time }}"
+          tags: "bigbluebutton/bbb-libreoffice:${{ github.ref_name }}"
           context: .
           cache-from: type=registry,ref=user/app:latest
           cache-to: type=inline


### PR DESCRIPTION
I still want to do the git tag in a way that includes both LibreOffice version plus a timestamp. However, also adding a timestamp on docker tag was excessive, resulting in things like `bigbluebutton/bbb-libreoffice:7.5.7-20231019--2023-10-19-071911`